### PR TITLE
Ft profile header component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import {HttpClientModule} from '@angular/common/http';
 import { ActivityComponent } from './components/activity/activity.component';
 import { TimelineComponent } from './components/activity/timeline/timeline.component';
 import { SupportersComponent } from './components/activity/supporters/supporters.component';
+import { ProfileHeaderComponent } from './components/profile-header/profile-header.component';
 
 
 @NgModule({
@@ -35,7 +36,8 @@ import { SupportersComponent } from './components/activity/supporters/supporters
     CampaignComponent,
     ActivityComponent,
     TimelineComponent,
-    SupportersComponent
+    SupportersComponent,
+    ProfileHeaderComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/profile-header/profile-header.component.html
+++ b/src/app/components/profile-header/profile-header.component.html
@@ -1,0 +1,3 @@
+<p>
+  {{displayName}}
+</p>

--- a/src/app/components/profile-header/profile-header.component.html
+++ b/src/app/components/profile-header/profile-header.component.html
@@ -1,3 +1,17 @@
-<p>
-  {{displayName}}
-</p>
+<section id="header" class="">
+  <div class="container bg-light py-4">
+    <div class="row">
+      <div class="col-2">
+        <img src="../../../assets/images/avatar.png" class="img-fluid rounded-circle float-left">
+      </div>
+      <div class="col ml-auto d-flex align-items-center">
+        <div id="entity-details">
+          <h2>{{displayName}}</h2>
+          <h5>{{contactName}}</h5>
+          <h6>{{location}}</h6>
+          <h6>Points: {{points}}</h6>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/app/components/profile-header/profile-header.component.spec.ts
+++ b/src/app/components/profile-header/profile-header.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProfileHeaderComponent } from './profile-header.component';
+
+describe('ProfileHeaderComponent', () => {
+  let component: ProfileHeaderComponent;
+  let fixture: ComponentFixture<ProfileHeaderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProfileHeaderComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProfileHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/profile-header/profile-header.component.ts
+++ b/src/app/components/profile-header/profile-header.component.ts
@@ -21,10 +21,22 @@ export class ProfileHeaderComponent implements OnInit {
   }
 
   get displayName() {
-    return this._entity.displayName;
+    return this._entity.displayName || this._entity.contactName;
   }
 
-  
+  get contactName() {
+    return this._entity.contactName;
+  }
+
+  get location() {
+    return this._entity.location;
+  }
+
+  get points() {
+    return this._entity.points;
+  }
+
+
   constructor() { }
 
   ngOnInit() {

--- a/src/app/components/profile-header/profile-header.component.ts
+++ b/src/app/components/profile-header/profile-header.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { HeaderEntity } from '../../models/HeaderEntity';
+
+@Component({
+  selector: 'app-profile-header',
+  templateUrl: './profile-header.component.html',
+  styleUrls: ['./profile-header.component.css']
+})
+export class ProfileHeaderComponent implements OnInit {
+
+  private _entity: HeaderEntity = {
+    displayName: '',
+    location: '',
+    points: 0,
+    contactName: 'string',
+  };
+
+  @Input()
+  set entity(entity: HeaderEntity) {
+    this._entity = entity;
+  }
+
+  get displayName() {
+    return this._entity.displayName;
+  }
+
+  
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/components/profile-header/profile-header.component.ts
+++ b/src/app/components/profile-header/profile-header.component.ts
@@ -12,7 +12,7 @@ export class ProfileHeaderComponent implements OnInit {
     displayName: '',
     location: '',
     points: 0,
-    contactName: 'string',
+    contactName: '',
   };
 
   @Input()

--- a/src/app/components/user-profile/user-profile.component.html
+++ b/src/app/components/user-profile/user-profile.component.html
@@ -1,3 +1,6 @@
+<app-profile-header [entity]="headerEntity">
+</app-profile-header>
+
 <p>
   user-profile works!
 </p>

--- a/src/app/components/user-profile/user-profile.component.ts
+++ b/src/app/components/user-profile/user-profile.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { HeaderEntity, HeaderEntityFactory } from '../../models/HeaderEntity';
 
 @Component({
   selector: 'app-user-profile',
@@ -6,6 +7,30 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./user-profile.component.css']
 })
 export class UserProfileComponent implements OnInit {
+
+  // some mock user stuff
+  private _user = {
+    firstName: 'Alice',
+    lastName: 'Janoski',
+    city: 'Washington',
+    location: 'USA',
+    username: 'ajanoski@yahoo.com',
+  }
+
+  get headerEntity(): HeaderEntity | null {
+    const user = this._user;
+    if (typeof user === 'undefined') {
+      return null;
+    }
+    const displayName = `${user.firstName} ${user.lastName}`;
+    const location = (user.city) ? `${user.city}, ${user.location}` : user.location;
+    const contactName = user.username;
+    // TODO: align what to do with points
+    const points = 0;
+    return HeaderEntityFactory.buildBasicHeaderEntity(
+      displayName, location, points, contactName
+    )
+  }
 
   constructor() { }
 

--- a/src/app/models/HeaderEntity.ts
+++ b/src/app/models/HeaderEntity.ts
@@ -1,0 +1,29 @@
+export interface HeaderEntity {
+  displayName: string;
+  location: string;
+  points: number;
+  contactName: string;
+}
+
+//TODO: lookup design patterns that could work well here
+
+export class BasicHeaderEntity implements HeaderEntity {
+  constructor(
+    readonly displayName: string,
+    readonly location: string,
+    readonly points: number,
+    readonly contactName: string
+  ) { }
+}
+
+
+export class HeaderEntityFactory {
+  static buildBasicHeaderEntity(
+    displayName: string,
+    location: string,
+    points: number,
+    contactName: string
+  ): HeaderEntity {
+    return new BasicHeaderEntity(displayName, location, points, contactName);
+  }
+}


### PR DESCRIPTION
**What**
A reusable component to disaplay header information
Is only used for rendering data passed from a parent component

Part of Story #5 - Profile Display 

_Could be applied to `user-profile` and `organization`, `event` etc components_

Is the darker area of
![image](https://user-images.githubusercontent.com/12134172/41370862-10dac462-6f49-11e8-9ff2-b10c3cd1d477.png)


**How**
By the means of _data binding_ any parent component can pass a `HeaderEntity` to this component to display.
